### PR TITLE
Add 'All accounts' mode

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback, useRef, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { useAppStore, useThreadedEmails, type Account, type SyncStatus, type PrefetchProgress, type BackgroundSyncProgress } from "./store";
+import { useAppStore, useThreadedEmails, getAccountColor, type Account, type SyncStatus, type PrefetchProgress, type BackgroundSyncProgress } from "./store";
 import { EmailList } from "./components/EmailList";
 import { EmailDetail } from "./components/EmailDetail";
 import { EmailPreviewSidebar } from "./components/EmailPreviewSidebar";
@@ -603,11 +603,15 @@ export default function App() {
           }));
           setAccounts(fullAccounts);
 
-          // Set current account to primary or first available
+          // Default to "All accounts" when multiple accounts, single account otherwise
+          if (fullAccounts.length > 1) {
+            setCurrentAccountId(null);
+          } else if (fullAccounts.length === 1) {
+            setCurrentAccountId(fullAccounts[0].id);
+          }
+
           const primaryAccount = fullAccounts.find(a => a.isPrimary) || fullAccounts[0];
           if (primaryAccount) {
-            setCurrentAccountId(primaryAccount.id);
-            // Identify user in PostHog using primary email
             identifyUser(primaryAccount.email, {
               account_count: fullAccounts.length,
             });
@@ -1230,9 +1234,12 @@ export default function App() {
 
   // Get current account and its sync status
   const currentAccount = accounts.find((a) => a.id === currentAccountId);
+  const isAllAccountsMode = currentAccountId === null && accounts.length > 0;
   const currentSyncStatus = currentAccountId ? getSyncStatus(currentAccountId) : "idle";
-  const isSyncing = currentSyncStatus === "syncing";
+  const isAnySyncing = isAllAccountsMode && accounts.some((a) => getSyncStatus(a.id) === "syncing");
+  const isSyncing = currentSyncStatus === "syncing" || isAnySyncing;
   const isCurrentAccountExpired = currentAccountId != null && expiredAccountIds.has(currentAccountId);
+  const isAnyAccountExpired = isAllAccountsMode && accounts.some((a) => expiredAccountIds.has(a.id));
 
   // Build list of expired accounts with their email addresses for the banner
   const expiredAccounts = accounts.filter((a) => expiredAccountIds.has(a.id));
@@ -1267,6 +1274,32 @@ export default function App() {
 
     // Trigger background sync to pick up any new emails (non-blocking)
     window.api.sync.now(accountId).catch(console.error);
+  };
+
+  const handleAllAccountsClick = () => {
+    setCurrentAccountId(null);
+    setAccountMenuOpen(false);
+    trackEvent("account_switched", { account_count: accounts.length, mode: "all" });
+
+    // Ensure all accounts have their emails loaded
+    const storeState = useAppStore.getState();
+    for (const account of accounts) {
+      if (!storeState.emails.some((e) => e.accountId === account.id)) {
+        window.api.sync.getEmails(account.id).then((result: IpcResponse<DashboardEmail[]>) => {
+          if (result.success && result.data && result.data.length > 0) {
+            addEmails(result.data);
+            prefetchEmailBodies(result.data.map((e: DashboardEmail) => e.id)).catch(console.error);
+          }
+        }).catch(console.error);
+      }
+      if (!storeState.sentEmails.some((e) => e.accountId === account.id)) {
+        window.api.sync.getSentEmails(account.id).then((sentResult: IpcResponse<DashboardEmail[]>) => {
+          if (sentResult.success && sentResult.data) {
+            addSentEmails(sentResult.data);
+          }
+        }).catch(console.error);
+      }
+    }
   };
 
   const handleCancelScheduled = async (id: string) => {
@@ -1307,7 +1340,7 @@ export default function App() {
                 className="flex items-center space-x-2 px-3 py-1.5 text-sm bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
               >
                 <span className="text-gray-700 dark:text-gray-300 truncate max-w-[200px]">
-                  {currentAccount?.email || "Select account"}
+                  {isAllAccountsMode ? "All accounts" : currentAccount?.email || "Select account"}
                 </span>
                 {/* Sync status indicator */}
                 {isSyncing && (
@@ -1316,13 +1349,13 @@ export default function App() {
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
                   </svg>
                 )}
-                {!isSyncing && !isCurrentAccountExpired && currentSyncStatus === "idle" && (
+                {!isSyncing && !isCurrentAccountExpired && !isAnyAccountExpired && (isAllAccountsMode || currentSyncStatus === "idle") && (
                   <span className="w-2 h-2 rounded-full bg-green-500" title="Connected" />
                 )}
-                {isCurrentAccountExpired && (
+                {(isCurrentAccountExpired || isAnyAccountExpired) && (
                   <span className="w-2 h-2 rounded-full bg-amber-500" title="Session expired" />
                 )}
-                {!isCurrentAccountExpired && currentSyncStatus === "error" && (
+                {!isCurrentAccountExpired && !isAnyAccountExpired && !isAllAccountsMode && currentSyncStatus === "error" && (
                   <span className="w-2 h-2 rounded-full bg-red-500" title="Sync error" />
                 )}
                 <svg className="w-4 h-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1334,6 +1367,21 @@ export default function App() {
               {accountMenuOpen && (
                 <div className="absolute top-full left-0 mt-1 w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg dark:shadow-black/40 z-50">
                   <div className="py-1">
+                    {accounts.length > 1 && (
+                      <button
+                        onClick={handleAllAccountsClick}
+                        className={`w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center space-x-2 ${
+                          isAllAccountsMode ? "bg-blue-50 dark:bg-blue-900/30" : ""
+                        }`}
+                      >
+                        <span className="flex -space-x-1">
+                          {accounts.slice(0, 3).map((a) => (
+                            <span key={a.id} className={`w-2 h-2 rounded-full ring-1 ring-white dark:ring-gray-800 ${getAccountColor(accounts, a.id).dot}`} />
+                          ))}
+                        </span>
+                        <span>All accounts</span>
+                      </button>
+                    )}
                     {accounts.map((account) => (
                       <button
                         key={account.id}
@@ -1343,11 +1391,11 @@ export default function App() {
                         }`}
                       >
                         <div className="flex items-center space-x-2">
-                          <span className={`w-2 h-2 rounded-full ${
-                            expiredAccountIds.has(account.id) ? "bg-amber-500" :
-                            account.isConnected ? "bg-green-500" : "bg-gray-400 dark:bg-gray-500"
-                          }`} />
+                          <span className={`w-2 h-2 rounded-full ${getAccountColor(accounts, account.id).dot}`} />
                           <span className="truncate">{account.email}</span>
+                          {expiredAccountIds.has(account.id) && (
+                            <span className="w-1.5 h-1.5 rounded-full bg-amber-500 flex-shrink-0" title="Session expired" />
+                          )}
                         </div>
                         {account.isPrimary && (
                           <span className="text-xs text-gray-500 dark:text-gray-400">Primary</span>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -170,7 +170,13 @@ function SearchResultsView() {
     remoteSearchLoadingMore,
   } = useAppStore();
 
-  const currentUserEmail = accounts.find(a => a.id === currentAccountId)?.email;
+  const searchUserEmails = useMemo(() => {
+    if (currentAccountId) {
+      const email = accounts.find(a => a.id === currentAccountId)?.email;
+      return email ? new Set([email]) : new Set<string>();
+    }
+    return new Set(accounts.map(a => a.email));
+  }, [currentAccountId, accounts]);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
@@ -259,11 +265,13 @@ function SearchResultsView() {
 
   // Merge local and remote results, deduplicate, and group into threads
   const searchThreads = useMemo(
-    () => mergeAndThreadSearchResults(activeSearchResults, remoteSearchResults, currentUserEmail),
-    [activeSearchResults, remoteSearchResults, currentUserEmail],
+    () => mergeAndThreadSearchResults(activeSearchResults, remoteSearchResults, searchUserEmails),
+    [activeSearchResults, remoteSearchResults, searchUserEmails],
   );
 
-  const hasMoreResults = !!remoteSearchNextPageToken && remoteSearchStatus === "complete";
+  // "Load more" only works when a single account is selected — in All accounts
+  // mode the stored nextPageToken is ambiguous (could be from any account).
+  const hasMoreResults = !!currentAccountId && !!remoteSearchNextPageToken && remoteSearchStatus === "complete";
 
   return (
     <div className="flex-1 min-w-0 flex flex-col bg-white dark:bg-gray-800">
@@ -603,9 +611,17 @@ export default function App() {
           }));
           setAccounts(fullAccounts);
 
-          // Default to "All accounts" when multiple accounts, single account otherwise
+          // Respect defaultAccountView config for startup account selection
+          const configResult = await window.api.settings.get();
+          const defaultView = configResult.success ? configResult.data.defaultAccountView ?? "all" : "all";
+
           if (fullAccounts.length > 1) {
-            setCurrentAccountId(null);
+            if (defaultView === "primary") {
+              const primary = fullAccounts.find(a => a.isPrimary) || fullAccounts[0];
+              setCurrentAccountId(primary.id);
+            } else {
+              setCurrentAccountId(null);
+            }
           } else if (fullAccounts.length === 1) {
             setCurrentAccountId(fullAccounts[0].id);
           }
@@ -1165,8 +1181,16 @@ export default function App() {
         // Reload sent emails too
         await reloadSentEmailsForAccount(currentAccountId);
       } else {
-        // Fallback to legacy fetch for default account
-        await fetchEmails();
+        // All accounts mode: sync every account and reload emails
+        await Promise.all(accounts.map(async (account) => {
+          await window.api.sync.now(account.id);
+          const result = await window.api.sync.getEmails(account.id);
+          if (result.success && result.data) {
+            addEmails(result.data);
+            prefetchEmailBodies(result.data.map((e: DashboardEmail) => e.id)).catch(console.error);
+          }
+          await reloadSentEmailsForAccount(account.id);
+        }));
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to fetch emails");
@@ -1763,7 +1787,10 @@ function SnoozeOverlay() {
 
   const selectedEmail = emails.find((e) => e.id === selectedEmailId);
 
-  if (!showSnoozeMenu || !selectedEmail || !currentAccountId) return null;
+  // In "All accounts" mode currentAccountId is null — derive from the selected email
+  const effectiveAccountId = currentAccountId ?? selectedEmail?.accountId ?? null;
+
+  if (!showSnoozeMenu || !selectedEmail || !effectiveAccountId) return null;
 
   // Determine if we're in batch mode (any multi-select, even 1 thread via 'x')
   const isBatchSnooze = selectedThreadIds.size > 0;
@@ -1783,7 +1810,7 @@ function SnoozeOverlay() {
         <SnoozeMenu
           emailId={selectedEmail.id}
           threadId={selectedEmail.threadId}
-          accountId={currentAccountId}
+          accountId={effectiveAccountId}
           onSnooze={(snoozedEmail: SnoozedEmail) => {
             if (isBatchSnooze) {
               // Batch snooze: snooze all selected threads using the same snoozeUntil time
@@ -1821,7 +1848,7 @@ function SnoozeOverlay() {
                       id: `snooze-${tid}-${Date.now()}`,
                       emailId: thread.latestEmail.id,
                       threadId: tid,
-                      accountId: currentAccountId,
+                      accountId: effectiveAccountId,
                       snoozeUntil: snoozedEmail.snoozeUntil,
                       snoozedAt: snoozedEmail.snoozedAt,
                     });
@@ -1836,7 +1863,7 @@ function SnoozeOverlay() {
                 id: `snooze-batch-${Date.now()}`,
                 type: "snooze",
                 threadCount: threadIdsToSnooze.length,
-                accountId: currentAccountId,
+                accountId: effectiveAccountId,
                 emails: [],
                 scheduledAt: Date.now(),
                 delayMs: 5000,
@@ -1850,7 +1877,7 @@ function SnoozeOverlay() {
                   (window as any).api.snooze.snooze(
                     thread.latestEmail.id,
                     tid,
-                    currentAccountId,
+                    effectiveAccountId,
                     snoozeUntil,
                   ).catch((err: unknown) => console.error("Batch snooze failed for thread", tid, err));
                 }
@@ -1893,7 +1920,7 @@ function SnoozeOverlay() {
                 id: `snooze-${snoozedThreadId}-${Date.now()}`,
                 type: "snooze",
                 threadCount: 1,
-                accountId: currentAccountId,
+                accountId: effectiveAccountId,
                 emails: [],
                 scheduledAt: Date.now(),
                 delayMs: 5000,

--- a/src/renderer/components/AgentCommandPalette.tsx
+++ b/src/renderer/components/AgentCommandPalette.tsx
@@ -149,9 +149,10 @@ export function AgentCommandPalette({ isOpen, onClose }: AgentCommandPaletteProp
   );
   const hasDraft = Boolean(selectedDraft);
 
+  const effectiveAccountId = currentAccountId ?? selectedEmail?.accountId ?? null;
   const currentAccount = useMemo(
-    () => accounts.find((a) => a.id === currentAccountId),
-    [accounts, currentAccountId]
+    () => accounts.find((a) => a.id === effectiveAccountId),
+    [accounts, effectiveAccountId]
   );
 
   // Suggested actions based on email context
@@ -222,7 +223,7 @@ export function AgentCommandPalette({ isOpen, onClose }: AgentCommandPaletteProp
 
       // Build context — include email metadata only when an email is selected
       const context: AgentContext = {
-        accountId: currentAccountId ?? "",
+        accountId: effectiveAccountId ?? "",
         userEmail: currentAccount?.email ?? "",
         userName: currentAccount?.displayName,
       };
@@ -274,7 +275,7 @@ export function AgentCommandPalette({ isOpen, onClose }: AgentCommandPaletteProp
     },
     [
       selectedAgentIds,
-      currentAccountId,
+      effectiveAccountId,
       selectedEmailId,
       selectedDraftId,
       selectedThreadId,

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -210,14 +210,16 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
         available: () => hasSelectedEmail,
         execute: () => {
           const state = useAppStore.getState();
-          if (state.selectedThreadId && state.currentAccountId) {
+          const selEmail = state.emails.find(e => e.id === state.selectedEmailId);
+          const accId = state.currentAccountId ?? selEmail?.accountId ?? null;
+          if (state.selectedThreadId && accId) {
             const threadEmails = state.emails.filter((e) => e.threadId === state.selectedThreadId);
             state.removeEmailsAndAdvance(threadEmails.map((e) => e.id), null, null);
             state.addUndoAction({
               id: `archive-${state.selectedThreadId}-${Date.now()}`,
               type: "archive",
               threadCount: 1,
-              accountId: state.currentAccountId,
+              accountId: accId,
               emails: [...threadEmails],
               scheduledAt: Date.now(),
               delayMs: 5000,
@@ -234,14 +236,16 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
         available: () => hasSelectedEmail,
         execute: () => {
           const state = useAppStore.getState();
-          if (state.selectedThreadId && state.currentAccountId) {
+          const selEmail = state.emails.find(e => e.id === state.selectedEmailId);
+          const accId = state.currentAccountId ?? selEmail?.accountId ?? null;
+          if (state.selectedThreadId && accId) {
             const threadEmails = state.emails.filter((e) => e.threadId === state.selectedThreadId);
             state.removeEmailsAndAdvance(threadEmails.map((e) => e.id), null, null);
             state.addUndoAction({
               id: `trash-${state.selectedThreadId}-${Date.now()}`,
               type: "trash",
               threadCount: 1,
-              accountId: state.currentAccountId,
+              accountId: accId,
               emails: [...threadEmails],
               scheduledAt: Date.now(),
               delayMs: 5000,
@@ -275,7 +279,9 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
         available: () => hasSelectedThread,
         execute: () => {
           const state = useAppStore.getState();
-          if (state.selectedThreadId && state.currentAccountId) {
+          const selEmail = state.emails.find(e => e.id === state.selectedEmailId);
+          const accId = state.currentAccountId ?? selEmail?.accountId ?? null;
+          if (state.selectedThreadId && accId) {
             const threadEmails = state.emails.filter(
               (e) => e.threadId === state.selectedThreadId
             );
@@ -292,7 +298,7 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
                   id: `mark-unread-${state.selectedThreadId}-${Date.now()}`,
                   type: "mark-unread",
                   threadCount: 1,
-                  accountId: state.currentAccountId,
+                  accountId: accId,
                   emails: [latest],
                   scheduledAt: Date.now(),
                   delayMs: 5000,
@@ -322,27 +328,26 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
         available: () => hasSelectedEmail,
         execute: () => {
           const state = useAppStore.getState();
-          if (state.selectedEmailId && state.currentAccountId) {
-            const email = state.emails.find((e) => e.id === state.selectedEmailId);
-            if (email) {
-              const currentLabels = email.labelIds || [];
-              const isStarred = currentLabels.includes("STARRED");
-              const previousLabels: Record<string, string[]> = { [email.id]: [...currentLabels] };
-              const newLabels = isStarred
-                ? currentLabels.filter((l) => l !== "STARRED")
-                : [...currentLabels, "STARRED"];
-              state.updateEmail(email.id, { labelIds: newLabels });
-              state.addUndoAction({
-                id: `${isStarred ? "unstar" : "star"}-${email.threadId}-${Date.now()}`,
-                type: isStarred ? "unstar" : "star",
-                threadCount: 1,
-                accountId: state.currentAccountId,
-                emails: [email],
-                scheduledAt: Date.now(),
-                delayMs: 5000,
-                previousLabels,
-              });
-            }
+          const selEmail = state.emails.find(e => e.id === state.selectedEmailId);
+          const accId = state.currentAccountId ?? selEmail?.accountId ?? null;
+          if (state.selectedEmailId && accId && selEmail) {
+            const currentLabels = selEmail.labelIds || [];
+            const isStarred = currentLabels.includes("STARRED");
+            const previousLabels: Record<string, string[]> = { [selEmail.id]: [...currentLabels] };
+            const newLabels = isStarred
+              ? currentLabels.filter((l) => l !== "STARRED")
+              : [...currentLabels, "STARRED"];
+            state.updateEmail(selEmail.id, { labelIds: newLabels });
+            state.addUndoAction({
+              id: `${isStarred ? "unstar" : "star"}-${selEmail.threadId}-${Date.now()}`,
+              type: isStarred ? "unstar" : "star",
+              threadCount: 1,
+              accountId: accId,
+              emails: [selEmail],
+              scheduledAt: Date.now(),
+              delayMs: 5000,
+              previousLabels,
+            });
           }
         },
       },
@@ -366,6 +371,8 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
           const state = useAppStore.getState();
           if (state.currentAccountId) {
             window.api.sync.now(state.currentAccountId);
+          } else {
+            for (const a of state.accounts) window.api.sync.now(a.id);
           }
         },
       },
@@ -463,7 +470,8 @@ export function CommandPalette({ isOpen, onClose }: CommandPaletteProps) {
           const email = state.emails.find((e) => e.id === selectedEmailId);
           if (!email) return;
 
-          const currentAccount = state.accounts.find((a) => a.id === state.currentAccountId);
+          const effectiveAccId = state.currentAccountId ?? email.accountId ?? null;
+          const currentAccount = state.accounts.find((a) => a.id === effectiveAccId);
           const userEmail = currentAccount?.email?.toLowerCase() ?? "";
 
           // Escape HTML special characters to prevent injection from email headers

--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -1938,9 +1938,12 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
 
   const selectedEmail = storeEmail ?? fetchedEmail;
 
-  // Get current user email for "Me" detection
-  const currentAccount = accounts.find(a => a.id === currentAccountId);
-  const currentUserEmail = currentAccount?.email;
+  // In "All accounts" mode currentAccountId is null, so derive the effective
+  // account from the selected email so thread fetch, attachments, compose, and
+  // actions all work correctly.
+  const effectiveAccountId = currentAccountId ?? selectedEmail?.accountId ?? null;
+  const effectiveAccount = accounts.find(a => a.id === effectiveAccountId);
+  const effectiveUserEmail = effectiveAccount?.email;
 
   // State to hold full thread emails fetched from Gmail (includes sent replies)
   const [fullThreadEmails, setFullThreadEmails] = useState<DashboardEmail[]>([]);
@@ -1948,7 +1951,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
 
   // Fetch full thread when thread changes
   useEffect(() => {
-    if (!selectedEmail || !currentAccountId) {
+    if (!selectedEmail || !effectiveAccountId) {
       setFullThreadEmails([]);
       return;
     }
@@ -1956,7 +1959,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
     const fetchThread = async () => {
       setIsLoadingThread(true);
       try {
-        const response = await (window as any).api.emails.getThread(selectedEmail.threadId, currentAccountId);
+        const response = await (window as any).api.emails.getThread(selectedEmail.threadId, effectiveAccountId);
         if (response.success && response.data) {
           setFullThreadEmails(response.data);
           // Push into the store so the sidebar can also resolve these emails
@@ -1971,7 +1974,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
     };
 
     fetchThread();
-  }, [selectedEmail?.threadId, currentAccountId]);
+  }, [selectedEmail?.threadId, effectiveAccountId]);
 
   // Mark-as-read is handled imperatively in the Enter/click handlers
   // (store.markThreadAsRead) — not here — so it fires instantly before render.
@@ -2015,13 +2018,13 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
   // The latest RECEIVED email (not sent by user) — used for analysis display
   // so that the user's own sent reply doesn't override the thread's analysis.
   const latestReceivedEmail = useMemo(() => {
-    if (!currentUserEmail) return latestEmail;
+    if (!effectiveUserEmail) return latestEmail;
     const received = threadEmails.filter(e => {
       const sender = e.from.match(/<(.+?)>/)?.[1] ?? e.from;
-      return sender.toLowerCase() !== currentUserEmail.toLowerCase();
+      return sender.toLowerCase() !== effectiveUserEmail.toLowerCase();
     });
     return received.length > 0 ? received[received.length - 1] : latestEmail;
-  }, [threadEmails, currentUserEmail, latestEmail]);
+  }, [threadEmails, effectiveUserEmail, latestEmail]);
 
   // The email that has an AI-generated draft attached — may differ from latestEmail
   // when the agent drafted on an earlier received email and a sent reply is now the latest.
@@ -2314,16 +2317,13 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
   // send time — they don't affect the visible UI.
   const composeRequestIdRef = useRef(0);
   useEffect(() => {
-    if (isFullView && composeState?.isOpen && composeState.replyToEmailId && currentAccountId) {
+    if (isFullView && composeState?.isOpen && composeState.replyToEmailId && effectiveAccountId) {
       const mode = composeState.mode;
       if (mode === "reply" || mode === "reply-all" || mode === "forward") {
         const requestId = ++composeRequestIdRef.current;
-        // Read fresh values from the store snapshot rather than closures so they
-        // don't need to be in the dependency array (this effect is event-driven
-        // by composeState, not reactive to email/account changes).
         const storeState = useAppStore.getState();
         const storeEmails = storeState.emails;
-        const acct = storeState.accounts.find(a => a.id === currentAccountId);
+        const acct = storeState.accounts.find(a => a.id === effectiveAccountId);
         const userEmail = acct?.email;
         // Find the email in the thread that has a draft (may not be the latest)
         const threadId = storeEmails.find(e => e.id === composeState.replyToEmailId)?.threadId;
@@ -2360,7 +2360,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
           // Fetch proper Message-ID/References headers in the background.
           // These only matter at send time for Gmail threading — the UI is
           // already fully interactive without them.
-          window.api.compose.getReplyInfo(composeState.replyToEmailId, mode, currentAccountId)
+          window.api.compose.getReplyInfo(composeState.replyToEmailId, mode, effectiveAccountId)
             .then((response: IpcResponse<ReplyInfo | null>) => {
               if (requestId !== composeRequestIdRef.current) return;
               if (response.success && response.data) {
@@ -2374,10 +2374,8 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
               // still works for threading, just less reliably.
             });
         } else {
-          // Email not in store (edge case: search result or archived email).
-          // Fall back to the IPC call.
           setIsLoadingReplyInfo(true);
-          window.api.compose.getReplyInfo(composeState.replyToEmailId, mode, currentAccountId)
+          window.api.compose.getReplyInfo(composeState.replyToEmailId, mode, effectiveAccountId)
             .then((response: IpcResponse<ReplyInfo | null>) => {
               if (requestId !== composeRequestIdRef.current) return;
               if (!response.success || !response.data) {
@@ -2396,7 +2394,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
         }
       }
     }
-  }, [isFullView, composeState, currentAccountId, closeCompose, setInlineReplyOpen]);
+  }, [isFullView, composeState, effectiveAccountId, closeCompose, setInlineReplyOpen]);
 
   // Safety net: if we're in full view with no valid email and no compose open,
   // fall back to split view so the email list becomes visible. This catches edge
@@ -2434,12 +2432,12 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
     // Add the sent email to the store optimistically.
     // Always use the current thread's threadId so forwards appear in the
     // thread view alongside the original email, just like replies do.
-    if (currentAccountId && currentUserEmail) {
+    if (effectiveAccountId && effectiveUserEmail) {
       const sentEmail: DashboardEmail = {
         id: sentInfo.id,
         threadId: selectedEmail?.threadId ?? sentInfo.threadId,
-        accountId: currentAccountId,
-        from: currentUserEmail,
+        accountId: effectiveAccountId,
+        from: effectiveUserEmail,
         to: sentInfo.to.join(", "),
         cc: sentInfo.cc?.join(", "),
         bcc: sentInfo.bcc?.join(", "),
@@ -2486,8 +2484,8 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
     setRestoredDraft(null);
     setInlineReplyOpen(false);
     // Also trigger sync to ensure we have the canonical version
-    if (currentAccountId) {
-      window.api.sync.now(currentAccountId);
+    if (effectiveAccountId) {
+      window.api.sync.now(effectiveAccountId);
     }
   };
 
@@ -2532,8 +2530,8 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
     closeCompose();
     setViewMode("split");
     // Trigger sync to get the sent message
-    if (currentAccountId) {
-      window.api.sync.now(currentAccountId);
+    if (effectiveAccountId) {
+      window.api.sync.now(effectiveAccountId);
     }
   };
 
@@ -2541,7 +2539,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
     const hasContent = formState.to.length > 0 || formState.subject.trim() || formState.bodyText.trim() || formState.bodyHtml.replace(/<[^>]*>/g, "").trim();
     const existingDraftId = composeState?.restoredDraft?.localDraftId;
 
-    if (hasContent && currentAccountId) {
+    if (hasContent && effectiveAccountId) {
       if (existingDraftId) {
         // Update existing draft with current form state
         await window.api.compose.updateLocalDraft(existingDraftId, {
@@ -2565,7 +2563,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
       } else {
         // Save new draft
         const result = await window.api.compose.saveLocalDraft({
-          accountId: currentAccountId,
+          accountId: effectiveAccountId,
           to: formState.to,
           cc: formState.cc.length > 0 ? formState.cc : undefined,
           bcc: formState.bcc.length > 0 ? formState.bcc : undefined,
@@ -2594,10 +2592,10 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
   };
 
   // Show new email compose view when in "new" compose mode
-  if (composeState?.isOpen && composeState.mode === "new" && currentAccountId) {
+  if (composeState?.isOpen && composeState.mode === "new" && effectiveAccountId) {
     return (
       <NewEmailCompose
-        accountId={currentAccountId}
+        accountId={effectiveAccountId}
         onSend={handleNewEmailSent}
         onCancel={handleNewEmailCancel}
         onDiscard={handleNewEmailDiscard}
@@ -2657,7 +2655,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
   const isStarred = threadEmails.some(e => e.labelIds?.includes("STARRED"));
 
   const handleArchive = () => {
-    if (!currentAccountId || !selectedThreadId) return;
+    if (!effectiveAccountId || !selectedThreadId) return;
     const emailIds = threadEmails.map(e => e.id);
 
     // Find next thread before removing
@@ -2680,7 +2678,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
       id: `archive-${selectedThreadId}-${Date.now()}`,
       type: "archive",
       threadCount: 1,
-      accountId: currentAccountId,
+      accountId: effectiveAccountId,
       emails: [...threadEmails],
       scheduledAt: Date.now(),
       delayMs: 5000,
@@ -2688,7 +2686,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
   };
 
   const handleTrash = () => {
-    if (!currentAccountId || !selectedThreadId) return;
+    if (!effectiveAccountId || !selectedThreadId) return;
     const emailIds = threadEmails.map(e => e.id);
 
     // Find next thread before removing (same auto-advance as archive)
@@ -2711,7 +2709,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
       id: `trash-${selectedThreadId}-${Date.now()}`,
       type: "trash",
       threadCount: 1,
-      accountId: currentAccountId,
+      accountId: effectiveAccountId,
       emails: [...threadEmails],
       scheduledAt: Date.now(),
       delayMs: 5000,
@@ -2719,7 +2717,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
   };
 
   const handleMarkUnread = () => {
-    if (!currentAccountId || !latestEmail) return;
+    if (!effectiveAccountId || !latestEmail) return;
     const currentLabels = latestEmail.labelIds || ["INBOX"];
 
     // Optimistic update + undo — only if email was actually modified
@@ -2730,7 +2728,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
         id: `mark-unread-${selectedThreadId}-${Date.now()}`,
         type: "mark-unread",
         threadCount: 1,
-        accountId: currentAccountId,
+        accountId: effectiveAccountId,
         emails: [latestEmail],
         scheduledAt: Date.now(),
         delayMs: 5000,
@@ -2742,7 +2740,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
   };
 
   const handleToggleStar = () => {
-    if (!currentAccountId || !latestEmail) return;
+    if (!effectiveAccountId || !latestEmail) return;
     const newStarred = !isStarred;
     const changedEmails: typeof threadEmails = [];
     const previousLabels: Record<string, string[]> = {};
@@ -2772,7 +2770,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
         id: `${newStarred ? "star" : "unstar"}-${selectedThreadId}-${Date.now()}`,
         type: newStarred ? "star" : "unstar",
         threadCount: 1,
-        accountId: currentAccountId,
+        accountId: effectiveAccountId,
         emails: changedEmails,
         scheduledAt: Date.now(),
         delayMs: 5000,
@@ -2897,7 +2895,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
         </div>
 
         {/* Snooze banner */}
-        {snoozedThreads.has(latestEmail.threadId) && currentAccountId && (() => {
+        {snoozedThreads.has(latestEmail.threadId) && effectiveAccountId && (() => {
           const snoozeInfo = snoozedThreads.get(latestEmail.threadId);
           return snoozeInfo ? (
             <div className="px-6 py-2.5 border-b border-amber-200 dark:border-amber-800/50 bg-amber-50 dark:bg-amber-900/20 flex items-center justify-between">
@@ -2911,7 +2909,7 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
               </div>
               <button
                 onClick={async () => {
-                  await (window as any).api.snooze.unsnooze(latestEmail.threadId, currentAccountId);
+                  await (window as any).api.snooze.unsnooze(latestEmail.threadId, effectiveAccountId);
                   removeSnoozedThread(latestEmail.threadId);
                 }}
                 className="text-xs text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200 font-medium"
@@ -2965,8 +2963,8 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
                 onReply={() => openCompose("reply", email.id)}
                 onReplyAll={() => openCompose("reply-all", email.id)}
                 onForward={() => openCompose("forward", email.id)}
-                currentUserEmail={currentUserEmail}
-                accountId={currentAccountId ?? undefined}
+                currentUserEmail={effectiveUserEmail}
+                accountId={effectiveAccountId ?? undefined}
                 threadEmails={threadEmails}
                 onPreviewAttachment={(attachment, data) => setPreviewAttachment({ attachment, data })}
               />
@@ -2977,12 +2975,12 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
               {/* Inline reply/forward — rendered inside the map right below the email being replied to.
                   When undo-send replaces an optimistic email ID, UndoSendToast atomically updates
                   inlineReplyToEmailId in the store so this condition keeps matching. */}
-              {inlineReplyToEmailId === email.id && inlineReplyInfo && currentAccountId && currentUserEmail && inlineComposeMode && (
+              {inlineReplyToEmailId === email.id && inlineReplyInfo && effectiveAccountId && effectiveUserEmail && inlineComposeMode && (
                 <InlineReply
                   key={`${inlineComposeMode}-${inlineReplyToEmailId}`}
                   replyInfo={inlineReplyInfo}
-                  accountId={currentAccountId}
-                  accountEmail={currentUserEmail}
+                  accountId={effectiveAccountId}
+                  accountEmail={effectiveUserEmail}
                   composeMode={inlineComposeMode}
                   replyToEmailId={inlineReplyToEmailId}
                   onSend={handleInlineReplySent}

--- a/src/renderer/components/EmailDetail.tsx
+++ b/src/renderer/components/EmailDetail.tsx
@@ -1940,8 +1940,14 @@ export function EmailDetail({ isFullView = false }: EmailDetailProps) {
 
   // In "All accounts" mode currentAccountId is null, so derive the effective
   // account from the selected email so thread fetch, attachments, compose, and
-  // actions all work correctly.
-  const effectiveAccountId = currentAccountId ?? selectedEmail?.accountId ?? null;
+  // actions all work correctly. Fall back to the primary/first account so that
+  // composing a new email works even when no email is selected.
+  const effectiveAccountId =
+    currentAccountId
+    ?? selectedEmail?.accountId
+    ?? accounts.find(a => a.isPrimary)?.id
+    ?? accounts[0]?.id
+    ?? null;
   const effectiveAccount = accounts.find(a => a.id === effectiveAccountId);
   const effectiveUserEmail = effectiveAccount?.email;
 

--- a/src/renderer/components/EmailList.tsx
+++ b/src/renderer/components/EmailList.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useCallback, useMemo } from "react";
 import type { InboxDensity, SnoozedEmail, DashboardEmail, LocalDraft } from "../../shared/types";
-import { useAppStore, useSplitFilteredThreads, type EmailThread } from "../store";
-import { EmailRow } from "./EmailRow";
+import { useAppStore, useSplitFilteredThreads, getAccountColor, getAccountLabel, type EmailThread, type Account } from "../store";
+import { EmailRow, type AccountBadge } from "./EmailRow";
 import { DraftRow } from "./DraftRow";
 import { BatchActionBar } from "./BatchActionBar";
 import { SplitTabs } from "./SplitTabs";
@@ -54,7 +54,26 @@ export function EmailList() {
   const allLocalDrafts = useAppStore((s) => s.localDrafts);
   const unsnoozedReturnTimes = useAppStore((s) => s.unsnoozedReturnTimes);
   const selectedThreadId = useAppStore((s) => s.selectedThreadId);
+  const accounts = useAppStore((s) => s.accounts);
   const { threads } = useSplitFilteredThreads();
+
+  const isAllAccountsMode = currentAccountId === null;
+
+  // Pre-compute account badges so EmailRow gets stable references (memo-friendly).
+  // Only computed in "All accounts" mode.
+  const accountBadgeMap = useMemo(() => {
+    if (!isAllAccountsMode || accounts.length === 0) return null;
+    const map = new Map<string, AccountBadge>();
+    for (const account of accounts) {
+      const color = getAccountColor(accounts, account.id);
+      map.set(account.id, {
+        label: getAccountLabel(account),
+        bgClass: color.bg,
+        textClass: color.text,
+      });
+    }
+    return map;
+  }, [isAllAccountsMode, accounts]);
 
   const isArchiveReadyView = currentSplitId === "__archive-ready__";
   const isDraftsView = currentSplitId === "__drafts__";
@@ -95,23 +114,25 @@ export function EmailList() {
   }, [openCompose, setSelectedEmailId, setSelectedThreadId, setSelectedDraftId, setViewMode]);
 
   // Load snoozed emails on mount / account switch.
-  // Also processes any snoozes that expired while the app was closed.
+  // In "All" mode, iterate over every account and merge results.
   useEffect(() => {
-    if (!currentAccountId) return;
-    (window as any).api.snooze.list(currentAccountId).then((response: any) => {
-      if (response.success && response.data) {
-        setSnoozedThreads(response.data);
-      }
-      // Process snoozes that expired while the app was closed —
-      // adds them to recentlyUnsnoozedThreadIds so they sort correctly
-      if (response.expired?.length > 0) {
-        const store = useAppStore.getState();
-        for (const email of response.expired) {
-          store.handleThreadUnsnoozed(email.threadId, email.snoozeUntil);
+    const accountIds = currentAccountId ? [currentAccountId] : accounts.map((a) => a.id);
+    if (accountIds.length === 0) return;
+
+    for (const accountId of accountIds) {
+      (window as any).api.snooze.list(accountId).then((response: any) => {
+        if (response.success && response.data) {
+          setSnoozedThreads(response.data);
         }
-      }
-    });
-  }, [currentAccountId, setSnoozedThreads]);
+        if (response.expired?.length > 0) {
+          const store = useAppStore.getState();
+          for (const email of response.expired) {
+            store.handleThreadUnsnoozed(email.threadId, email.snoozeUntil);
+          }
+        }
+      });
+    }
+  }, [currentAccountId, accounts, setSnoozedThreads]);
 
   // Listen for snooze events from main process, filtered by current account.
   // Uses useAppStore.getState() inside callbacks so we don't need action refs
@@ -120,20 +141,23 @@ export function EmailList() {
   currentAccountRef.current = currentAccountId;
 
   useEffect(() => {
+    const matchesAccount = (accountId: string) =>
+      currentAccountRef.current === null || accountId === currentAccountRef.current;
+
     (window as any).api.snooze.onUnsnoozed((data: { emails: SnoozedEmail[] }) => {
       for (const email of data.emails) {
-        if (email.accountId === currentAccountRef.current) {
+        if (matchesAccount(email.accountId)) {
           useAppStore.getState().handleThreadUnsnoozed(email.threadId, email.snoozeUntil);
         }
       }
     });
     (window as any).api.snooze.onSnoozed((data: { snoozedEmail: SnoozedEmail }) => {
-      if (data.snoozedEmail.accountId === currentAccountRef.current) {
+      if (matchesAccount(data.snoozedEmail.accountId)) {
         useAppStore.getState().addSnoozedThread(data.snoozedEmail);
       }
     });
     (window as any).api.snooze.onManuallyUnsnoozed((data: { threadId: string; accountId: string; snoozeUntil: number }) => {
-      if (data.accountId === currentAccountRef.current) {
+      if (matchesAccount(data.accountId)) {
         useAppStore.getState().handleThreadUnsnoozed(data.threadId, data.snoozeUntil);
       }
     });
@@ -143,19 +167,24 @@ export function EmailList() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Load archive-ready threads on mount / account switch
+  // Load archive-ready threads on mount / account switch.
+  // In "All" mode, iterate over every account and merge results.
   useEffect(() => {
-    if (!currentAccountId) return;
-    (window as any).api.archiveReady.getThreads(currentAccountId).then((result: any) => {
-      if (result.success && result.data) {
-        const items = result.data.map((t: { threadId: string; reason: string }) => ({
-          threadId: t.threadId,
-          reason: t.reason,
-        }));
-        setArchiveReadyThreads(items);
-      }
-    });
-  }, [currentAccountId, setArchiveReadyThreads]);
+    const accountIds = currentAccountId ? [currentAccountId] : accounts.map((a) => a.id);
+    if (accountIds.length === 0) return;
+
+    for (const accountId of accountIds) {
+      (window as any).api.archiveReady.getThreads(accountId).then((result: any) => {
+        if (result.success && result.data) {
+          const items = result.data.map((t: { threadId: string; reason: string }) => ({
+            threadId: t.threadId,
+            reason: t.reason,
+          }));
+          setArchiveReadyThreads(items);
+        }
+      });
+    }
+  }, [currentAccountId, accounts, setArchiveReadyThreads]);
 
   // Listen for new archive-ready results from background prefetch
   const currentAccountRef2 = useRef(currentAccountId);
@@ -164,7 +193,7 @@ export function EmailList() {
   useEffect(() => {
     (window as any).api.archiveReady.onResult(
       (data: { threadId: string; accountId: string; isReady: boolean; reason: string }) => {
-        if (data.accountId !== currentAccountRef2.current) return;
+        if (currentAccountRef2.current !== null && data.accountId !== currentAccountRef2.current) return;
         if (data.isReady) {
           // Add single thread to the set
           useAppStore.setState((state) => {
@@ -599,6 +628,7 @@ export function EmailList() {
                     onCheckboxChange={() => handleCheckboxToggle(thread.threadId)}
                     snoozeInfo={isSnoozedView ? snoozedThreads.get(thread.threadId) : undefined}
                     returnTime={unsnoozedReturnTimes.get(thread.threadId)}
+                    accountBadge={accountBadgeMap?.get(thread.latestEmail.accountId ?? "") }
                   />
                 </div>
               );

--- a/src/renderer/components/EmailList.tsx
+++ b/src/renderer/components/EmailList.tsx
@@ -114,24 +114,27 @@ export function EmailList() {
   }, [openCompose, setSelectedEmailId, setSelectedThreadId, setSelectedDraftId, setViewMode]);
 
   // Load snoozed emails on mount / account switch.
-  // In "All" mode, iterate over every account and merge results.
+  // In "All" mode, fetch every account in parallel then merge before calling the
+  // setter once — setSnoozedThreads is a replace operation so calling it per-account
+  // in a loop would discard all but the last response.
   useEffect(() => {
     const accountIds = currentAccountId ? [currentAccountId] : accounts.map((a) => a.id);
     if (accountIds.length === 0) return;
 
-    for (const accountId of accountIds) {
+    const promises = accountIds.map((accountId) =>
       (window as any).api.snooze.list(accountId).then((response: any) => {
-        if (response.success && response.data) {
-          setSnoozedThreads(response.data);
-        }
         if (response.expired?.length > 0) {
           const store = useAppStore.getState();
           for (const email of response.expired) {
             store.handleThreadUnsnoozed(email.threadId, email.snoozeUntil);
           }
         }
-      });
-    }
+        return response.success && response.data ? response.data : [];
+      })
+    );
+    Promise.all(promises).then((results) => {
+      setSnoozedThreads(results.flat());
+    });
   }, [currentAccountId, accounts, setSnoozedThreads]);
 
   // Listen for snooze events from main process, filtered by current account.
@@ -168,22 +171,26 @@ export function EmailList() {
   }, []);
 
   // Load archive-ready threads on mount / account switch.
-  // In "All" mode, iterate over every account and merge results.
+  // Same Promise.all pattern as snooze loading — setArchiveReadyThreads replaces
+  // state, so we must collect all accounts before calling it once.
   useEffect(() => {
     const accountIds = currentAccountId ? [currentAccountId] : accounts.map((a) => a.id);
     if (accountIds.length === 0) return;
 
-    for (const accountId of accountIds) {
+    const promises = accountIds.map((accountId) =>
       (window as any).api.archiveReady.getThreads(accountId).then((result: any) => {
         if (result.success && result.data) {
-          const items = result.data.map((t: { threadId: string; reason: string }) => ({
+          return result.data.map((t: { threadId: string; reason: string }) => ({
             threadId: t.threadId,
             reason: t.reason,
           }));
-          setArchiveReadyThreads(items);
         }
-      });
-    }
+        return [];
+      })
+    );
+    Promise.all(promises).then((results) => {
+      setArchiveReadyThreads(results.flat());
+    });
   }, [currentAccountId, accounts, setArchiveReadyThreads]);
 
   // Listen for new archive-ready results from background prefetch

--- a/src/renderer/components/EmailRow.tsx
+++ b/src/renderer/components/EmailRow.tsx
@@ -3,6 +3,12 @@ import type { InboxDensity, SnoozedEmail } from "../../shared/types";
 import type { EmailThread } from "../store";
 import { formatSnoozeTime } from "./SnoozeMenu";
 
+export interface AccountBadge {
+  label: string;
+  bgClass: string;
+  textClass: string;
+}
+
 interface EmailRowProps {
   thread: EmailThread;
   isSelected: boolean;
@@ -13,6 +19,7 @@ interface EmailRowProps {
   onCheckboxChange: () => void;
   snoozeInfo?: SnoozedEmail;
   returnTime?: number; // Unsnooze return time — shown instead of last message time
+  accountBadge?: AccountBadge;
 }
 
 // Density-specific style maps
@@ -104,7 +111,7 @@ function getPriorityLabel(thread: EmailThread): { text: string; className: strin
 // Memoized so that j/k navigation only re-renders the two rows whose
 // isSelected changed, not every row in the list.  The custom comparator
 // skips onClick/onCheckboxChange (always new arrow functions from the parent).
-export const EmailRow = memo(function EmailRow({ thread, isSelected, isChecked, isMultiSelectActive, density, onClick, onCheckboxChange, snoozeInfo, returnTime }: EmailRowProps) {
+export const EmailRow = memo(function EmailRow({ thread, isSelected, isChecked, isMultiSelectActive, density, onClick, onCheckboxChange, snoozeInfo, returnTime, accountBadge }: EmailRowProps) {
   const senderName = extractSenderName(thread.displaySender);
   const time = returnTime
     ? formatRelativeDate(new Date(returnTime).toISOString())
@@ -187,6 +194,19 @@ export const EmailRow = memo(function EmailRow({ thread, isSelected, isChecked, 
         </span>
       )}
 
+      {/* Account badge (shown in "All accounts" mode) */}
+      {accountBadge && (
+        <span className={`
+          ${ds.priorityBadge} rounded flex-shrink-0 font-medium truncate max-w-[10rem]
+          ${isSelected && !isChecked
+            ? "bg-white/20 text-white"
+            : `${accountBadge.bgClass} ${accountBadge.textClass}`
+          }
+        `}>
+          {accountBadge.label}
+        </span>
+      )}
+
       {/* Subject + Snippet (combined to use available space) */}
       <div className={`flex-1 min-w-0 flex items-center ${density === "compact" ? "gap-1.5" : "gap-2"}`}>
         <span className={`font-medium truncate flex-shrink-0 max-w-[85%] ${
@@ -261,7 +281,8 @@ export const EmailRow = memo(function EmailRow({ thread, isSelected, isChecked, 
   prev.isMultiSelectActive === next.isMultiSelectActive &&
   prev.density === next.density &&
   prev.snoozeInfo === next.snoozeInfo &&
-  prev.returnTime === next.returnTime
+  prev.returnTime === next.returnTime &&
+  prev.accountBadge === next.accountBadge
   // onClick / onCheckboxChange intentionally omitted — they are stable in behavior
   // but are new arrow function references on each parent render.
 );

--- a/src/renderer/components/SearchBar.tsx
+++ b/src/renderer/components/SearchBar.tsx
@@ -51,6 +51,7 @@ export function SearchBar({ isOpen, onClose }: SearchBarProps) {
   const {
     setSelectedEmailId,
     currentAccountId,
+    accounts,
     setActiveSearch,
     setViewMode,
     isOnline,
@@ -111,7 +112,8 @@ export function SearchBar({ isOpen, onClose }: SearchBarProps) {
 
   // Perform full Gmail search and show results (local + remote in parallel)
   const performFullSearch = useCallback(() => {
-    if (!query.trim() || !currentAccountId) return;
+    const accountIds = currentAccountId ? [currentAccountId] : accounts.map(a => a.id);
+    if (!query.trim() || accountIds.length === 0) return;
 
     // Special handling for "in:draft" / "in:drafts" — switch to drafts view instead of searching
     const trimmed = query.trim().toLowerCase();
@@ -123,42 +125,56 @@ export function SearchBar({ isOpen, onClose }: SearchBarProps) {
 
     trackEvent("search_performed");
 
-    // Close modal immediately and show SearchResultsView with loading state.
-    // setActiveSearch closes the modal, sets remoteSearchStatus: 'searching'.
     setActiveSearch(query, []);
 
-    // Fire local search — results stream into the store when ready
-    window.api.emails.search(query, currentAccountId, 500)
-      .then((localResponse: IpcResponse<DashboardEmail[]>) => {
-        if (useAppStore.getState().activeSearchQuery !== query) return;
-        if (localResponse.success && localResponse.data) {
-          useAppStore.getState().setActiveSearchResults(localResponse.data);
-        }
-      })
-      .catch((error: unknown) => {
-        console.error("Local search failed:", error);
-      });
-
-    // Fire remote search (slow) — results stream into the store when ready
-    if (isOnline) {
-      window.api.emails.searchRemote(query, currentAccountId, 500)
-        .then((response: { success: boolean; data?: { emails: DashboardEmail[]; nextPageToken?: string }; error?: string }) => {
+    // Fire local search for each account and merge results
+    for (const accountId of accountIds) {
+      window.api.emails.search(query, accountId, 500)
+        .then((localResponse: IpcResponse<DashboardEmail[]>) => {
           if (useAppStore.getState().activeSearchQuery !== query) return;
-          if (response.success && response.data) {
-            setRemoteSearchResults(response.data.emails);
-            useAppStore.getState().setRemoteSearchNextPageToken(response.data.nextPageToken ?? null);
-          } else {
-            setRemoteSearchError(response.error || "Gmail search failed");
+          if (localResponse.success && localResponse.data) {
+            const existing = useAppStore.getState().activeSearchResults ?? [];
+            const existingIds = new Set(existing.map(e => e.id));
+            const newEmails = localResponse.data.filter(e => !existingIds.has(e.id));
+            if (newEmails.length > 0) {
+              useAppStore.getState().setActiveSearchResults([...existing, ...newEmails]);
+            }
           }
         })
-        .catch((err: unknown) => {
-          if (useAppStore.getState().activeSearchQuery !== query) return;
-          setRemoteSearchError(err instanceof Error ? err.message : "Gmail search failed");
+        .catch((error: unknown) => {
+          console.error("Local search failed:", error);
         });
+    }
+
+    // Fire remote search for each account and merge results
+    if (isOnline) {
+      for (const accountId of accountIds) {
+        window.api.emails.searchRemote(query, accountId, 500)
+          .then((response: { success: boolean; data?: { emails: DashboardEmail[]; nextPageToken?: string }; error?: string }) => {
+            if (useAppStore.getState().activeSearchQuery !== query) return;
+            if (response.success && response.data) {
+              const existing = useAppStore.getState().remoteSearchResults ?? [];
+              const existingIds = new Set(existing.map(e => e.id));
+              const newEmails = response.data.emails.filter(e => !existingIds.has(e.id));
+              if (newEmails.length > 0) {
+                setRemoteSearchResults([...existing, ...newEmails]);
+              }
+              if (response.data.nextPageToken) {
+                useAppStore.getState().setRemoteSearchNextPageToken(response.data.nextPageToken);
+              }
+            } else {
+              setRemoteSearchError(response.error || "Gmail search failed");
+            }
+          })
+          .catch((err: unknown) => {
+            if (useAppStore.getState().activeSearchQuery !== query) return;
+            setRemoteSearchError(err instanceof Error ? err.message : "Gmail search failed");
+          });
+      }
     } else {
       setRemoteSearchResults([]);
     }
-  }, [query, currentAccountId, isOnline, setActiveSearch, setRemoteSearchResults, setRemoteSearchError, setCurrentSplitId, onClose]);
+  }, [query, currentAccountId, accounts, isOnline, setActiveSearch, setRemoteSearchResults, setRemoteSearchError, setCurrentSplitId, onClose]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/src/renderer/components/SearchBar.tsx
+++ b/src/renderer/components/SearchBar.tsx
@@ -146,9 +146,11 @@ export function SearchBar({ isOpen, onClose }: SearchBarProps) {
         });
     }
 
-    // Fire remote search for each account and merge results
+    // Fire remote search for each account and merge results.
+    // Use Promise.all to ensure remoteSearchStatus transitions to "complete"
+    // even when all accounts return empty or fully-deduplicated results.
     if (isOnline) {
-      for (const accountId of accountIds) {
+      const remotePromises = accountIds.map((accountId) =>
         window.api.emails.searchRemote(query, accountId, 500)
           .then((response: { success: boolean; data?: { emails: DashboardEmail[]; nextPageToken?: string }; error?: string }) => {
             if (useAppStore.getState().activeSearchQuery !== query) return;
@@ -171,8 +173,17 @@ export function SearchBar({ isOpen, onClose }: SearchBarProps) {
           .catch((err: unknown) => {
             if (useAppStore.getState().activeSearchQuery !== query) return;
             setRemoteSearchError(err instanceof Error ? err.message : "Gmail search failed");
-          });
-      }
+          })
+      );
+      Promise.all(remotePromises).then(() => {
+        // If no individual response called setRemoteSearchResults (e.g. all
+        // results were empty or duplicates), the status is still "searching".
+        // Force it to "complete" so the spinner stops.
+        const s = useAppStore.getState();
+        if (s.activeSearchQuery === query && s.remoteSearchStatus === "searching") {
+          setRemoteSearchResults(s.remoteSearchResults ?? []);
+        }
+      });
     } else {
       setRemoteSearchResults([]);
     }

--- a/src/renderer/components/SearchBar.tsx
+++ b/src/renderer/components/SearchBar.tsx
@@ -159,7 +159,9 @@ export function SearchBar({ isOpen, onClose }: SearchBarProps) {
               if (newEmails.length > 0) {
                 setRemoteSearchResults([...existing, ...newEmails]);
               }
-              if (response.data.nextPageToken) {
+              // Only store nextPageToken for single-account searches — in All
+              // accounts mode the token is ambiguous and "load more" is disabled.
+              if (response.data.nextPageToken && currentAccountId) {
                 useAppStore.getState().setRemoteSearchNextPageToken(response.data.nextPageToken);
               }
             } else {

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -1219,6 +1219,65 @@ export function SettingsPanel({ onClose, initialTab }: SettingsPanelProps) {
                 )}
               </div>
 
+              {/* Default Inbox View — only relevant with multiple accounts */}
+              {accounts.length > 1 && (
+                <div className="mb-6">
+                  <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-1">Default Inbox View</h3>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
+                    Choose which view to show when the app starts.
+                  </p>
+                  <div className="space-y-2">
+                    <label
+                      className={`flex items-center p-3 rounded-lg border cursor-pointer transition-colors ${
+                        (generalConfig?.defaultAccountView ?? "all") === "all"
+                          ? "border-blue-500 dark:border-blue-400 bg-blue-50 dark:bg-blue-900/30"
+                          : "border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500"
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="defaultAccountView"
+                        value="all"
+                        checked={(generalConfig?.defaultAccountView ?? "all") === "all"}
+                        onChange={() => window.api.settings.set({ defaultAccountView: "all" }).then(() => queryClient.invalidateQueries({ queryKey: ["general-config"] }))}
+                        className="sr-only"
+                      />
+                      <div>
+                        <div className="text-sm font-medium text-gray-900 dark:text-gray-100">All accounts</div>
+                        <div className="text-xs text-gray-500 dark:text-gray-400">Show combined inbox from all accounts on startup</div>
+                      </div>
+                    </label>
+                    <label
+                      className={`flex items-center p-3 rounded-lg border cursor-pointer transition-colors ${
+                        (generalConfig?.defaultAccountView ?? "all") === "primary"
+                          ? "border-blue-500 dark:border-blue-400 bg-blue-50 dark:bg-blue-900/30"
+                          : "border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500"
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="defaultAccountView"
+                        value="primary"
+                        checked={(generalConfig?.defaultAccountView ?? "all") === "primary"}
+                        onChange={() => window.api.settings.set({ defaultAccountView: "primary" }).then(() => queryClient.invalidateQueries({ queryKey: ["general-config"] }))}
+                        className="sr-only"
+                      />
+                      <div>
+                        <div className="text-sm font-medium text-gray-900 dark:text-gray-100">Primary account</div>
+                        <div className="text-xs text-gray-500 dark:text-gray-400">
+                          Show only the primary account on startup
+                          {accounts.find(a => a.isPrimary) && (
+                            <span className="ml-1 text-blue-600 dark:text-blue-400">
+                              ({accounts.find(a => a.isPrimary)!.email})
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </label>
+                  </div>
+                </div>
+              )}
+
               {/* Add account button */}
               <button
                 onClick={handleAddAccount}

--- a/src/renderer/hooks/useBatchActions.ts
+++ b/src/renderer/hooks/useBatchActions.ts
@@ -9,7 +9,8 @@ import { trackEvent } from "../services/posthog";
 
 export function batchArchive() {
   const { selectedThreadIds, emails, removeEmails, clearSelectedThreads, addUndoAction, currentAccountId } = useAppStore.getState();
-  if (!currentAccountId || selectedThreadIds.size === 0) return;
+  const effectiveAccountId = currentAccountId ?? emails.find(e => selectedThreadIds.has(e.threadId))?.accountId ?? null;
+  if (!effectiveAccountId || selectedThreadIds.size === 0) return;
 
   const threadIds = Array.from(selectedThreadIds);
   const allEmailIds: string[] = [];
@@ -32,18 +33,18 @@ export function batchArchive() {
     id: `archive-batch-${Date.now()}`,
     type: "archive",
     threadCount: threadIds.length,
-    accountId: currentAccountId,
+    accountId: effectiveAccountId,
     emails: [...allEmails],
     scheduledAt: Date.now(),
     delayMs: 5000,
   });
-  // Tracks intent — user may still undo within 5 s
   trackEvent("email_archived", { thread_count: threadIds.length, source: "batch" });
 }
 
 export function batchTrash() {
   const { selectedThreadIds, emails, removeEmails, clearSelectedThreads, addUndoAction, currentAccountId } = useAppStore.getState();
-  if (!currentAccountId || selectedThreadIds.size === 0) return;
+  const effectiveAccountId = currentAccountId ?? emails.find(e => selectedThreadIds.has(e.threadId))?.accountId ?? null;
+  if (!effectiveAccountId || selectedThreadIds.size === 0) return;
 
   const threadIds = Array.from(selectedThreadIds);
   const allEmailIds: string[] = [];
@@ -65,18 +66,18 @@ export function batchTrash() {
     id: `trash-batch-${Date.now()}`,
     type: "trash",
     threadCount: threadIds.length,
-    accountId: currentAccountId,
+    accountId: effectiveAccountId,
     emails: [...allEmails],
     scheduledAt: Date.now(),
     delayMs: 5000,
   });
-  // Tracks intent — user may still undo within 5 s
   trackEvent("email_trashed", { thread_count: threadIds.length, source: "batch" });
 }
 
 export function batchToggleStar() {
   const { selectedThreadIds, emails, clearSelectedThreads, updateEmail, addUndoAction, currentAccountId } = useAppStore.getState();
-  if (!currentAccountId || selectedThreadIds.size === 0) return;
+  const effectiveAccountId = currentAccountId ?? emails.find(e => selectedThreadIds.has(e.threadId))?.accountId ?? null;
+  if (!effectiveAccountId || selectedThreadIds.size === 0) return;
 
   // Group emails by thread for the selected threads
   const selectedThreadEmails: Array<{ threadId: string; emails: typeof emails }> = [];
@@ -123,7 +124,7 @@ export function batchToggleStar() {
       id: `${actionType}-batch-${Date.now()}`,
       type: actionType,
       threadCount: selectedThreadIds.size,
-      accountId: currentAccountId,
+      accountId: effectiveAccountId,
       emails: changedEmails,
       scheduledAt: Date.now(),
       delayMs: 5000,
@@ -136,7 +137,8 @@ export function batchToggleStar() {
 
 export function batchMarkUnread() {
   const { selectedThreadIds, emails, clearSelectedThreads, updateEmail, addUndoAction, currentAccountId } = useAppStore.getState();
-  if (!currentAccountId || selectedThreadIds.size === 0) return;
+  const effectiveAccountId = currentAccountId ?? emails.find(e => selectedThreadIds.has(e.threadId))?.accountId ?? null;
+  if (!effectiveAccountId || selectedThreadIds.size === 0) return;
 
   const changedEmails: DashboardEmail[] = [];
   const previousLabels: Record<string, string[]> = {};
@@ -163,7 +165,7 @@ export function batchMarkUnread() {
       id: `mark-unread-batch-${Date.now()}`,
       type: "mark-unread",
       threadCount: changedEmails.length,
-      accountId: currentAccountId,
+      accountId: effectiveAccountId,
       emails: changedEmails,
       scheduledAt: Date.now(),
       delayMs: 5000,

--- a/src/renderer/hooks/useBatchActions.ts
+++ b/src/renderer/hooks/useBatchActions.ts
@@ -5,79 +5,102 @@ import { trackEvent } from "../services/posthog";
 /**
  * Shared batch action functions that read current state from the store.
  * Safe to call from event handlers, useCallback bodies, or keyboard shortcuts.
+ *
+ * In "All accounts" mode (currentAccountId === null) the selected threads may
+ * span multiple accounts. Each undo action carries a single accountId, so we
+ * group emails by account and create one undo action per account.
  */
 
+function groupEmailsByAccount(emails: DashboardEmail[]): Map<string, DashboardEmail[]> {
+  const byAccount = new Map<string, DashboardEmail[]>();
+  for (const email of emails) {
+    const acct = email.accountId;
+    const list = byAccount.get(acct);
+    if (list) {
+      list.push(email);
+    } else {
+      byAccount.set(acct, [email]);
+    }
+  }
+  return byAccount;
+}
+
 export function batchArchive() {
-  const { selectedThreadIds, emails, removeEmails, clearSelectedThreads, addUndoAction, currentAccountId } = useAppStore.getState();
-  const effectiveAccountId = currentAccountId ?? emails.find(e => selectedThreadIds.has(e.threadId))?.accountId ?? null;
-  if (!effectiveAccountId || selectedThreadIds.size === 0) return;
+  const { selectedThreadIds, emails, removeEmails, clearSelectedThreads, addUndoAction } = useAppStore.getState();
+  if (selectedThreadIds.size === 0) return;
 
   const threadIds = Array.from(selectedThreadIds);
   const allEmailIds: string[] = [];
-  const emailsByThread = new Map<string, DashboardEmail[]>();
+  const allEmails: DashboardEmail[] = [];
   for (const threadId of threadIds) {
     const threadEmails = emails.filter((e) => e.threadId === threadId);
-    emailsByThread.set(threadId, threadEmails);
     for (const email of threadEmails) {
       allEmailIds.push(email.id);
+      allEmails.push(email);
     }
   }
 
-  // Optimistic UI: remove all emails from selected threads
-  const allEmails = threadIds.flatMap(tid => emailsByThread.get(tid) || []);
+  if (allEmails.length === 0) return;
+
   removeEmails(allEmailIds);
   clearSelectedThreads();
 
-  // Queue a single undo action for all threads
-  addUndoAction({
-    id: `archive-batch-${Date.now()}`,
-    type: "archive",
-    threadCount: threadIds.length,
-    accountId: effectiveAccountId,
-    emails: [...allEmails],
-    scheduledAt: Date.now(),
-    delayMs: 5000,
-  });
+  // One undo action per account so the backend receives the correct accountId
+  const byAccount = groupEmailsByAccount(allEmails);
+  for (const [accountId, accountEmails] of byAccount) {
+    const accountThreadCount = new Set(accountEmails.map(e => e.threadId)).size;
+    addUndoAction({
+      id: `archive-batch-${accountId}-${Date.now()}`,
+      type: "archive",
+      threadCount: accountThreadCount,
+      accountId,
+      emails: accountEmails,
+      scheduledAt: Date.now(),
+      delayMs: 5000,
+    });
+  }
   trackEvent("email_archived", { thread_count: threadIds.length, source: "batch" });
 }
 
 export function batchTrash() {
-  const { selectedThreadIds, emails, removeEmails, clearSelectedThreads, addUndoAction, currentAccountId } = useAppStore.getState();
-  const effectiveAccountId = currentAccountId ?? emails.find(e => selectedThreadIds.has(e.threadId))?.accountId ?? null;
-  if (!effectiveAccountId || selectedThreadIds.size === 0) return;
+  const { selectedThreadIds, emails, removeEmails, clearSelectedThreads, addUndoAction } = useAppStore.getState();
+  if (selectedThreadIds.size === 0) return;
 
   const threadIds = Array.from(selectedThreadIds);
   const allEmailIds: string[] = [];
-  const emailsByThread = new Map<string, DashboardEmail[]>();
+  const allEmails: DashboardEmail[] = [];
   for (const threadId of threadIds) {
     const threadEmails = emails.filter((e) => e.threadId === threadId);
-    emailsByThread.set(threadId, threadEmails);
     for (const email of threadEmails) {
       allEmailIds.push(email.id);
+      allEmails.push(email);
     }
   }
 
-  const allEmails = threadIds.flatMap(tid => emailsByThread.get(tid) || []);
+  if (allEmails.length === 0) return;
+
   removeEmails(allEmailIds);
   clearSelectedThreads();
 
-  // Queue a single undo action for all threads
-  addUndoAction({
-    id: `trash-batch-${Date.now()}`,
-    type: "trash",
-    threadCount: threadIds.length,
-    accountId: effectiveAccountId,
-    emails: [...allEmails],
-    scheduledAt: Date.now(),
-    delayMs: 5000,
-  });
+  const byAccount = groupEmailsByAccount(allEmails);
+  for (const [accountId, accountEmails] of byAccount) {
+    const accountThreadCount = new Set(accountEmails.map(e => e.threadId)).size;
+    addUndoAction({
+      id: `trash-batch-${accountId}-${Date.now()}`,
+      type: "trash",
+      threadCount: accountThreadCount,
+      accountId,
+      emails: accountEmails,
+      scheduledAt: Date.now(),
+      delayMs: 5000,
+    });
+  }
   trackEvent("email_trashed", { thread_count: threadIds.length, source: "batch" });
 }
 
 export function batchToggleStar() {
-  const { selectedThreadIds, emails, clearSelectedThreads, updateEmail, addUndoAction, currentAccountId } = useAppStore.getState();
-  const effectiveAccountId = currentAccountId ?? emails.find(e => selectedThreadIds.has(e.threadId))?.accountId ?? null;
-  if (!effectiveAccountId || selectedThreadIds.size === 0) return;
+  const { selectedThreadIds, emails, clearSelectedThreads, updateEmail, addUndoAction } = useAppStore.getState();
+  if (selectedThreadIds.size === 0) return;
 
   // Group emails by thread for the selected threads
   const selectedThreadEmails: Array<{ threadId: string; emails: typeof emails }> = [];
@@ -120,25 +143,31 @@ export function batchToggleStar() {
 
   if (changedEmails.length > 0) {
     const actionType = anyUnstarred ? "star" : "unstar";
-    addUndoAction({
-      id: `${actionType}-batch-${Date.now()}`,
-      type: actionType,
-      threadCount: selectedThreadIds.size,
-      accountId: effectiveAccountId,
-      emails: changedEmails,
-      scheduledAt: Date.now(),
-      delayMs: 5000,
-      previousLabels,
-    });
+    const byAccount = groupEmailsByAccount(changedEmails);
+    for (const [accountId, accountEmails] of byAccount) {
+      const accountPrevLabels: Record<string, string[]> = {};
+      for (const e of accountEmails) {
+        if (previousLabels[e.id]) accountPrevLabels[e.id] = previousLabels[e.id];
+      }
+      addUndoAction({
+        id: `${actionType}-batch-${accountId}-${Date.now()}`,
+        type: actionType,
+        threadCount: new Set(accountEmails.map(e => e.threadId)).size,
+        accountId,
+        emails: accountEmails,
+        scheduledAt: Date.now(),
+        delayMs: 5000,
+        previousLabels: accountPrevLabels,
+      });
+    }
     const changedThreadCount = new Set(changedEmails.map(e => e.threadId)).size;
     trackEvent(anyUnstarred ? "email_starred" : "email_unstarred", { thread_count: changedThreadCount });
   }
 }
 
 export function batchMarkUnread() {
-  const { selectedThreadIds, emails, clearSelectedThreads, updateEmail, addUndoAction, currentAccountId } = useAppStore.getState();
-  const effectiveAccountId = currentAccountId ?? emails.find(e => selectedThreadIds.has(e.threadId))?.accountId ?? null;
-  if (!effectiveAccountId || selectedThreadIds.size === 0) return;
+  const { selectedThreadIds, emails, clearSelectedThreads, updateEmail, addUndoAction } = useAppStore.getState();
+  if (selectedThreadIds.size === 0) return;
 
   const changedEmails: DashboardEmail[] = [];
   const previousLabels: Record<string, string[]> = {};
@@ -150,7 +179,6 @@ export function batchMarkUnread() {
       new Date(a.date).getTime() >= new Date(b.date).getTime() ? a : b
     );
     const currentLabels = latestEmail.labelIds || ["INBOX"];
-    // Only mark emails that aren't already unread
     if (!currentLabels.includes("UNREAD")) {
       previousLabels[latestEmail.id] = [...currentLabels];
       updateEmail(latestEmail.id, { labelIds: [...currentLabels, "UNREAD"] });
@@ -161,16 +189,23 @@ export function batchMarkUnread() {
   clearSelectedThreads();
 
   if (changedEmails.length > 0) {
-    addUndoAction({
-      id: `mark-unread-batch-${Date.now()}`,
-      type: "mark-unread",
-      threadCount: changedEmails.length,
-      accountId: effectiveAccountId,
-      emails: changedEmails,
-      scheduledAt: Date.now(),
-      delayMs: 5000,
-      previousLabels,
-    });
+    const byAccount = groupEmailsByAccount(changedEmails);
+    for (const [accountId, accountEmails] of byAccount) {
+      const accountPrevLabels: Record<string, string[]> = {};
+      for (const e of accountEmails) {
+        if (previousLabels[e.id]) accountPrevLabels[e.id] = previousLabels[e.id];
+      }
+      addUndoAction({
+        id: `mark-unread-batch-${accountId}-${Date.now()}`,
+        type: "mark-unread",
+        threadCount: new Set(accountEmails.map(e => e.threadId)).size,
+        accountId,
+        emails: accountEmails,
+        scheduledAt: Date.now(),
+        delayMs: 5000,
+        previousLabels: accountPrevLabels,
+      });
+    }
     trackEvent("email_marked_unread", { thread_count: new Set(changedEmails.map(e => e.threadId)).size });
   }
 }

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -102,6 +102,10 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
 
       const isGmail = keyboardBindings === "gmail";
 
+      const effectiveAccountId = currentAccountId
+        ?? emails.find(em => em.id === selectedEmailId)?.accountId
+        ?? null;
+
       // Store actions are stable references — safe to read from getState()
       const {
         setSelectedEmailId,
@@ -387,7 +391,7 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
       };
 
       // --- Helper: merge+dedup+thread search results (same order as rendered list) ---
-      const currentUserEmail = accounts.find((a: { id: string }) => a.id === currentAccountId)?.email;
+      const currentUserEmail = accounts.find((a: { id: string }) => a.id === effectiveAccountId)?.email;
       const getSearchThreads = () =>
         mergeAndThreadSearchResults(activeSearchResults, remoteSearchResults, currentUserEmail);
 
@@ -422,7 +426,7 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
 
       // --- Helper: archive selected thread (all messages) ---
       const archiveSelected = () => {
-        if (!selectedEmailId || !selectedThreadId || !currentAccountId) return;
+        if (!selectedEmailId || !selectedThreadId || !effectiveAccountId) return;
 
         // Collect ALL emails in the thread for optimistic removal
         const threadEmails = getThreadEmails(selectedThreadId);
@@ -470,20 +474,18 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
           id: `archive-${selectedThreadId}-${Date.now()}`,
           type: "archive",
           threadCount: 1,
-          accountId: currentAccountId,
+          accountId: effectiveAccountId,
           emails: [...threadEmails],
           scheduledAt: Date.now(),
           delayMs: 5000,
-          // If archive-ready view, include thread ID so it gets cleaned up on execute
           archiveReadyThreadIds: isArchiveReady ? [selectedThreadId] : undefined,
         });
-        // Tracks intent — user may still undo within 5 s
         trackEvent("email_archived", { thread_count: 1, source: "keyboard" });
       };
 
       // --- Helper: trash selected thread ---
       const trashSelected = () => {
-        if (!selectedEmailId || !selectedThreadId || !currentAccountId) return;
+        if (!selectedEmailId || !selectedThreadId || !effectiveAccountId) return;
 
         const threadEmails = getThreadEmails(selectedThreadId);
         const threadEmailIds = threadEmails.map((item) => item.id);
@@ -528,18 +530,17 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
           id: `trash-${selectedThreadId}-${Date.now()}`,
           type: "trash",
           threadCount: 1,
-          accountId: currentAccountId,
+          accountId: effectiveAccountId,
           emails: [...threadEmails],
           scheduledAt: Date.now(),
           delayMs: 5000,
         });
-        // Tracks intent — user may still undo within 5 s
         trackEvent("email_trashed", { thread_count: 1, source: "keyboard" });
       };
 
       // --- Helper: mark selected thread as unread ---
       const markSelectedUnread = () => {
-        if (!selectedThreadId || !currentAccountId) return;
+        if (!selectedThreadId || !effectiveAccountId) return;
 
         const threadEmails = emails.filter((item) => item.threadId === selectedThreadId);
         if (threadEmails.length === 0) return;
@@ -558,7 +559,7 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
             id: `mark-unread-${selectedThreadId}-${Date.now()}`,
             type: "mark-unread",
             threadCount: 1,
-            accountId: currentAccountId,
+            accountId: effectiveAccountId,
             emails: [latestEmail],
             scheduledAt: Date.now(),
             delayMs: 5000,
@@ -869,7 +870,7 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
         // Shift+I: mark as read and return to list (Gmail only)
         case "I":
           if (isGmail && e.shiftKey) {
-            if (selectedThreadId && currentAccountId) {
+            if (selectedThreadId && effectiveAccountId) {
               e.preventDefault();
               markThreadAsRead(selectedThreadId);
               if (viewMode === "full") {
@@ -884,7 +885,7 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
           if (isMultiSelect) {
             e.preventDefault();
             batchToggleStar();
-          } else if (isGmail && selectedThreadId && currentAccountId) {
+          } else if (isGmail && selectedThreadId && effectiveAccountId) {
             e.preventDefault();
             const threadEmails = emails.filter((item) => item.threadId === selectedThreadId);
             if (threadEmails.length === 0) break;
@@ -906,7 +907,7 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
                 id: `unstar-${selectedThreadId}-${Date.now()}`,
                 type: "unstar",
                 threadCount: 1,
-                accountId: currentAccountId,
+                accountId: effectiveAccountId,
                 emails: starredEmails,
                 scheduledAt: Date.now(),
                 delayMs: 5000,
@@ -920,7 +921,7 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
                 id: `star-${selectedThreadId}-${Date.now()}`,
                 type: "star",
                 threadCount: 1,
-                accountId: currentAccountId,
+                accountId: effectiveAccountId,
                 emails: [latestEmail],
                 scheduledAt: Date.now(),
                 delayMs: 5000,
@@ -979,9 +980,13 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
 
         // Shift+N: force refresh/sync current account (Gmail only)
         case "N":
-          if (isGmail && e.shiftKey && currentAccountId) {
+          if (isGmail && e.shiftKey) {
             e.preventDefault();
-            window.api.sync.now(currentAccountId).catch(console.error);
+            if (currentAccountId) {
+              window.api.sync.now(currentAccountId).catch(console.error);
+            } else {
+              for (const a of accounts) window.api.sync.now(a.id).catch(console.error);
+            }
           }
           break;
 

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -391,9 +391,11 @@ export function useKeyboardShortcuts(options: UseKeyboardShortcutsOptions = {}) 
       };
 
       // --- Helper: merge+dedup+thread search results (same order as rendered list) ---
-      const currentUserEmail = accounts.find((a: { id: string }) => a.id === effectiveAccountId)?.email;
+      const kbUserEmails = effectiveAccountId
+        ? new Set([accounts.find((a: { id: string }) => a.id === effectiveAccountId)?.email].filter(Boolean) as string[])
+        : new Set(accounts.map((a: { email: string }) => a.email));
       const getSearchThreads = () =>
-        mergeAndThreadSearchResults(activeSearchResults, remoteSearchResults, currentUserEmail);
+        mergeAndThreadSearchResults(activeSearchResults, remoteSearchResults, kbUserEmails);
 
       // --- Helper: navigate search results up/down (by thread) ---
       const navigateSearchResults = (direction: "up" | "down") => {

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -57,6 +57,31 @@ export type Account = {
   isConnected: boolean;
 };
 
+// Deterministic account color palette — assigned by index in the accounts array
+export type AccountColor = {
+  bg: string;
+  text: string;
+  dot: string;
+};
+
+const ACCOUNT_COLORS: AccountColor[] = [
+  { bg: "bg-blue-100 dark:bg-blue-900/30", text: "text-blue-700 dark:text-blue-300", dot: "bg-blue-500" },
+  { bg: "bg-purple-100 dark:bg-purple-900/30", text: "text-purple-700 dark:text-purple-300", dot: "bg-purple-500" },
+  { bg: "bg-green-100 dark:bg-green-900/30", text: "text-green-700 dark:text-green-300", dot: "bg-green-500" },
+  { bg: "bg-orange-100 dark:bg-orange-900/30", text: "text-orange-700 dark:text-orange-300", dot: "bg-orange-500" },
+  { bg: "bg-pink-100 dark:bg-pink-900/30", text: "text-pink-700 dark:text-pink-300", dot: "bg-pink-500" },
+  { bg: "bg-teal-100 dark:bg-teal-900/30", text: "text-teal-700 dark:text-teal-300", dot: "bg-teal-500" },
+];
+
+export function getAccountColor(accounts: Account[], accountId: string): AccountColor {
+  const idx = accounts.findIndex((a) => a.id === accountId);
+  return ACCOUNT_COLORS[(idx === -1 ? 0 : idx) % ACCOUNT_COLORS.length];
+}
+
+export function getAccountLabel(account: Account): string {
+  return account.email;
+}
+
 // Sync status per account
 export type SyncStatus = "idle" | "syncing" | "error";
 
@@ -736,14 +761,14 @@ export const useAppStore = create<AppState>((set, get) => ({
     })),
   // Multi-account actions
   setAccounts: (accounts) =>
-    set({
-      accounts,
-      // Set current to primary or first account if not set
-      currentAccountId:
-        get().currentAccountId ||
-        accounts.find((a) => a.isPrimary)?.id ||
-        accounts[0]?.id ||
-        null,
+    set((state) => {
+      if (state.currentAccountId !== null) return { accounts };
+      // Default to "All accounts" (null) when multiple accounts exist,
+      // otherwise select the single account directly.
+      return {
+        accounts,
+        currentAccountId: accounts.length > 1 ? null : accounts[0]?.id ?? null,
+      };
     }),
   addAccount: (account) =>
     set((state) => {

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -1614,25 +1614,29 @@ export function getAppStateSnapshot(): Record<string, unknown> {
   return state;
 }
 
-// Check if an email is sent by the user (not received)
-function isSentEmail(email: DashboardEmail, currentUserEmail?: string): boolean {
+// Check if an email is sent by the user (not received).
+// Accepts a Set of user emails to support "All accounts" mode where multiple
+// accounts may be active.
+function isSentEmail(email: DashboardEmail, userEmails?: Set<string>): boolean {
   // Check labelIds first (most reliable)
   if (email.labelIds?.includes("SENT")) {
     return true;
   }
 
   // Fall back to checking the from field
-  if (!currentUserEmail) return false;
+  if (!userEmails || userEmails.size === 0) return false;
   const fromLower = email.from.toLowerCase();
-  const userEmailLower = currentUserEmail.toLowerCase();
   // Extract email from "Name <email>" format if present
   const emailMatch = fromLower.match(/<([^>]+)>/) || [null, fromLower];
-  const fromEmail = emailMatch[1] || fromLower;
-  return fromEmail.trim() === userEmailLower.trim();
+  const fromEmail = (emailMatch[1] || fromLower).trim();
+  for (const ue of userEmails) {
+    if (fromEmail === ue.toLowerCase().trim()) return true;
+  }
+  return false;
 }
 
 // Helper to group emails by thread
-export function groupByThread(emails: DashboardEmail[], currentUserEmail?: string): EmailThread[] {
+export function groupByThread(emails: DashboardEmail[], userEmails?: Set<string>): EmailThread[] {
   const threadMap = new Map<string, DashboardEmail[]>();
 
   // Pre-compute timestamps once to avoid creating Date objects in every sort
@@ -1659,23 +1663,23 @@ export function groupByThread(emails: DashboardEmail[], currentUserEmail?: strin
     const latestEmail = threadEmails[threadEmails.length - 1];
 
     // Find the latest RECEIVED email (not sent by user) for inbox sorting
-    const receivedEmails = threadEmails.filter(e => !isSentEmail(e, currentUserEmail));
+    const receivedEmails = threadEmails.filter(e => !isSentEmail(e, userEmails));
     const latestReceivedEmail = receivedEmails.length > 0
       ? receivedEmails[receivedEmails.length - 1]
       : latestEmail; // Fallback to latest if all are sent
 
     // Determine if the user was the last to reply
-    const userReplied = isSentEmail(latestEmail, currentUserEmail);
+    const userReplied = isSentEmail(latestEmail, userEmails);
 
     // Find the best sender to display - last person who isn't the current user.
     // Handles edge cases where latestReceivedEmail falls back to the user's own email
     // (e.g., thread with only sent emails, or emails missing SENT label).
     let displaySender: string;
-    if (!isSentEmail(latestReceivedEmail, currentUserEmail)) {
+    if (!isSentEmail(latestReceivedEmail, userEmails)) {
       displaySender = latestReceivedEmail.from;
     } else {
       // latestReceivedEmail is from user - find any non-self email
-      const nonSelfEmail = [...threadEmails].reverse().find(e => !isSentEmail(e, currentUserEmail));
+      const nonSelfEmail = [...threadEmails].reverse().find(e => !isSentEmail(e, userEmails));
       if (nonSelfEmail) {
         displaySender = nonSelfEmail.from;
       } else {
@@ -1731,9 +1735,15 @@ export function useThreadedEmails() {
   const snoozedThreadIds = useAppStore((state) => state.snoozedThreadIds);
   const recentlyRepliedThreadIds = useAppStore((state) => state.recentlyRepliedThreadIds);
 
-  // Get current user's email for sent detection
-  const currentAccount = accounts.find(a => a.id === currentAccountId);
-  const currentUserEmail = currentAccount?.email;
+  // Build set of user emails for sent detection — in All accounts mode this
+  // includes every account's email so isSentEmail works across accounts.
+  const userEmails = useMemo(() => {
+    if (currentAccountId) {
+      const email = accounts.find(a => a.id === currentAccountId)?.email;
+      return email ? new Set([email]) : new Set<string>();
+    }
+    return new Set(accounts.map(a => a.email));
+  }, [currentAccountId, accounts]);
 
   // Memoize the expensive thread computation. j/k navigation only changes
   // selectedEmailId — none of these deps change, so the memo short-circuits
@@ -1751,11 +1761,11 @@ export function useThreadedEmails() {
       ? emails.filter((e) => e.accountId === currentAccountId && (isInboxEmail(e) || e.labelIds?.includes("SENT")))
       : emails.filter((e) => isInboxEmail(e) || e.labelIds?.includes("SENT"));
 
-    // Group into threads first, passing current user email for sent detection
+    // Group into threads first, passing user emails for sent detection.
     // Then filter out sent-only threads — threads where no email has the INBOX label.
     // Sent emails within inbox threads are kept (for conversation context), but threads
     // consisting solely of sent emails belong in the Sent view, not the inbox.
-    const allThreads = groupByThread(accountEmails, currentUserEmail)
+    const allThreads = groupByThread(accountEmails, userEmails)
       .filter((t) => t.emails.some((e) => !e.labelIds || e.labelIds.includes("INBOX")));
 
     // Separate snoozed threads from active threads
@@ -1817,7 +1827,7 @@ export function useThreadedEmails() {
       snoozed,
       snoozedCount: snoozed.length,
     };
-  }, [emails, currentAccountId, currentUserEmail, snoozedThreadIds, recentlyRepliedThreadIds]);
+  }, [emails, currentAccountId, userEmails, snoozedThreadIds, recentlyRepliedThreadIds]);
 }
 
 function threadMatchesSplit(thread: EmailThread, split: InboxSplit): boolean {
@@ -1867,12 +1877,13 @@ export function useSplitFilteredThreads() {
 
     // Handle sent virtual split — show sent emails grouped by thread
     if (currentSplitId === "__sent__") {
-      const currentAccount = accounts.find(a => a.id === currentAccountId);
-      const currentUserEmail = currentAccount?.email;
+      const sentUserEmails = currentAccountId
+        ? new Set([accounts.find(a => a.id === currentAccountId)?.email].filter(Boolean) as string[])
+        : new Set(accounts.map(a => a.email));
       const sentAccountEmails = currentAccountId
         ? sentEmails.filter(e => e.accountId === currentAccountId)
         : sentEmails;
-      const sentThreads = groupByThread(sentAccountEmails, currentUserEmail)
+      const sentThreads = groupByThread(sentAccountEmails, sentUserEmails)
         .sort((a, b) => new Date(b.latestEmail.date).getTime() - new Date(a.latestEmail.date).getTime());
 
       return {

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -1521,10 +1521,11 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   markThreadAsRead: (threadId) => {
     const state = get();
-    const accountId = state.currentAccountId;
-    if (!accountId) return;
-
     const threadEmails = state.emails.filter((e) => e.threadId === threadId);
+
+    // In All accounts mode, derive the accountId from the thread's emails
+    const accountId = state.currentAccountId ?? threadEmails[0]?.accountId ?? null;
+    if (!accountId) return;
     const unreadEmails = threadEmails.filter((e) => e.labelIds?.includes("UNREAD"));
     if (unreadEmails.length === 0) return;
 

--- a/src/renderer/utils/searchResults.ts
+++ b/src/renderer/utils/searchResults.ts
@@ -39,10 +39,10 @@ export function mergeAndSortSearchResults(
 export function mergeAndThreadSearchResults(
   localResults: readonly DashboardEmail[],
   remoteResults: readonly DashboardEmail[],
-  currentUserEmail?: string,
+  userEmails?: Set<string>,
 ): EmailThread[] {
   const merged = mergeAndSortSearchResults(localResults, remoteResults);
-  const threads = groupByThread(merged, currentUserEmail);
+  const threads = groupByThread(merged, userEmails);
   // Re-sort by latest email date (including sent) for search results.
   // groupByThread sorts by latestReceivedDate (for inbox), but search results
   // should sort by overall recency to match the displayed time.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -385,6 +385,7 @@ export const ConfigSchema = z.object({
     sessionReplay: z.boolean().default(false),
   }).optional(),
   keyboardBindings: z.enum(["superhuman", "gmail"]).default("superhuman"),
+  defaultAccountView: z.enum(["all", "primary"]).default("all"),
   openclaw: z.object({
     enabled: z.boolean().default(false),
     gatewayUrl: z.string().default(""),

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,5 @@
+import forms from '@tailwindcss/forms';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   darkMode: "class",
@@ -9,6 +11,6 @@ export default {
     extend: {},
   },
   plugins: [
-    require('@tailwindcss/forms'),
+    forms,
   ],
 }


### PR DESCRIPTION
I wanted a way to view all my inboxes in one view, so implemented a "All accounts" in the account selector. If you dont want PRs or this do not make sense, please feel fee to close it :) 

Thanks for a great project!

------
Introduce an "All accounts" mode (currentAccountId === null) and propagate an effectiveAccountId throughout the renderer so actions, sync, compose, search, snooze, archive-ready, batch actions and keyboard shortcuts work when multiple accounts are selected. Key changes:

- App: default selection logic updated to use "All accounts" when multiple accounts exist; added account switch handler to load/prefetch emails for all accounts; compute aggregate sync/expired status and update UI indicators.
- Store: add deterministic account color palette and helpers (getAccountColor, getAccountLabel) for badges.
- EmailList / EmailRow: show per-account badges in All mode, merge snooze/archiveReady loads across accounts, and listen for cross-account snooze/archive events.
- EmailDetail, AgentCommandPalette, CommandPalette, SearchBar, useBatchActions, useKeyboardShortcuts: derive effectiveAccountId (currentAccountId || related email.accountId) so commands, optimistic actions, compose/reply info, searches (local+remote) and batch/keyboard operations target the correct account when in All mode.
- Search: run local and remote searches across all accounts and merge results deduplicating by id.

These changes make the app behave correctly when viewing or operating across all accounts while preserving single-account behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ankitvgupta/mail-app/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
